### PR TITLE
Cleanup and update of build scripts and package manifests

### DIFF
--- a/stomp_core/CMakeLists.txt
+++ b/stomp_core/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES stomp_core
-  CATKIN_DEPENDS roscpp cmake_modules
+  CATKIN_DEPENDS roscpp
   DEPENDS EIGEN3
 )
 

--- a/stomp_core/CMakeLists.txt
+++ b/stomp_core/CMakeLists.txt
@@ -6,21 +6,21 @@ add_definitions("-std=c++11")
 find_package(Eigen3 REQUIRED)
 
 find_package(catkin REQUIRED COMPONENTS
-  roscpp
   cmake_modules
+  rosconsole
+  xmlrpcpp
 )
 
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
+find_package(Boost REQUIRED)
 
 ###################################
 ## catkin specific configuration ##
 ###################################
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES stomp_core
-  CATKIN_DEPENDS roscpp
-  DEPENDS EIGEN3
+  LIBRARIES ${PROJECT_NAME}
+  CATKIN_DEPENDS rosconsole xmlrpcpp
+  DEPENDS Boost EIGEN3
 )
 
 ###########
@@ -31,6 +31,7 @@ include_directories(
   examples
   ${catkin_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
 )
 
 ## Declare a C++ library
@@ -39,7 +40,7 @@ add_library(${PROJECT_NAME}
    src/utils.cpp
 )
 
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_executable(${PROJECT_NAME}_example examples/stomp_example.cpp)
 target_link_libraries(${PROJECT_NAME}_example ${PROJECT_NAME} ${catkin_LIBRARIES})

--- a/stomp_core/package.xml
+++ b/stomp_core/package.xml
@@ -15,7 +15,6 @@
   <build_depend>roscpp</build_depend>
   <build_depend>eigen</build_depend>   
 
-  <run_depend>cmake_modules</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>eigen</run_depend>
 

--- a/stomp_core/package.xml
+++ b/stomp_core/package.xml
@@ -12,10 +12,17 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>boost</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>eigen</build_depend>
 
-  <depend>roscpp</depend>
+  <build_export_depend>boost</build_export_depend>
+  <build_export_depend>eigen</build_export_depend>
+
+  <depend>rosconsole</depend>
+  <depend>xmlrpcpp</depend>
+
+  <test_depend>rosunit</test_depend>
 
   <export>
     <rosdoc config="rosdoc.yaml"/>

--- a/stomp_core/package.xml
+++ b/stomp_core/package.xml
@@ -1,22 +1,21 @@
 <?xml version="1.0"?>
-<package>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
   <name>stomp_core</name>
   <version>0.1.1</version>
-  <description>The stomp_core package</description>
-
+  <description>The stomp_core package.</description>
+  <author>Jorge Nicho</author>
   <maintainer email="jrgnichodevel@gmail.com">Jorge Nicho</maintainer>
   <license>Apache 2.0</license>
-  <author email="jrgnichodevel@gmail.com">Jorge Nicho</author>
-  <url type="website">http://ros.org/wiki/stomp_core</url>
-  
+
+  <url type="website">http://wiki.ros.org/stomp_core</url>
+
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>cmake_modules</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>eigen</build_depend>   
+  <build_depend>eigen</build_depend>
 
-  <run_depend>roscpp</run_depend>
-  <run_depend>eigen</run_depend>
+  <depend>roscpp</depend>
 
   <export>
     <rosdoc config="rosdoc.yaml"/>

--- a/stomp_moveit/CMakeLists.txt
+++ b/stomp_moveit/CMakeLists.txt
@@ -23,7 +23,7 @@ add_definitions("-std=c++11")
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS moveit_ros_planning moveit_core stomp_core cmake_modules pluginlib roscpp kdl_parser trac_ik_lib
+  CATKIN_DEPENDS moveit_ros_planning moveit_core stomp_core pluginlib roscpp kdl_parser trac_ik_lib
   DEPENDS EIGEN3
 )
 

--- a/stomp_moveit/CMakeLists.txt
+++ b/stomp_moveit/CMakeLists.txt
@@ -1,15 +1,19 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(stomp_moveit)
 find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  moveit_core
-  moveit_ros_planning
-  stomp_core
   cmake_modules
-  pluginlib
-  kdl_parser
-  trac_ik_lib
   eigen_conversions
+  geometry_msgs
+  kdl_parser
+  moveit_core
+  moveit_msgs
+  moveit_ros_planning
+  pluginlib
+  roscpp
+  stomp_core
+  tf
+  trac_ik_lib
+  visualization_msgs
 )
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system)
@@ -23,8 +27,21 @@ add_definitions("-std=c++11")
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS moveit_ros_planning moveit_core stomp_core pluginlib roscpp kdl_parser trac_ik_lib
-  DEPENDS EIGEN3
+  CATKIN_DEPENDS
+    geometry_msgs
+    kdl_parser
+    moveit_core
+    moveit_msgs
+    moveit_ros_planning
+    pluginlib
+    roscpp
+    stomp_core
+    tf
+    trac_ik_lib
+    visualization_msgs
+  DEPENDS
+    Boost
+    EIGEN3
 )
 
 ###########
@@ -40,8 +57,8 @@ include_directories(include
 add_library(${PROJECT_NAME}
   src/stomp_optimization_task.cpp
   src/stomp_planner.cpp
-  src/utils/polynomial.cpp
   src/utils/kinematics.cpp
+  src/utils/polynomial.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}
@@ -62,7 +79,7 @@ target_link_libraries(${PROJECT_NAME}_cost_functions ${catkin_LIBRARIES})
 
 # filter plugin(s)
 add_library(${PROJECT_NAME}_noisy_filters
-  src/noisy_filters/joint_limits.cpp  
+  src/noisy_filters/joint_limits.cpp
   src/noisy_filters/multi_trajectory_visualization.cpp
 )
 
@@ -70,9 +87,9 @@ target_link_libraries(${PROJECT_NAME}_noisy_filters ${catkin_LIBRARIES})
 
 # update plugin(s)
 add_library(${PROJECT_NAME}_update_filters
+  src/update_filters/control_cost_projection.cpp
   src/update_filters/polynomial_smoother.cpp
   src/update_filters/trajectory_visualization.cpp
-  src/update_filters/control_cost_projection.cpp
   src/update_filters/update_logger.cpp
   src/utils/polynomial.cpp
  )
@@ -93,14 +110,24 @@ install(DIRECTORY include/${PROJECT_NAME}/
 )
 
 ## Mark executables and/or libraries for installation
-install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_planner_manager ${PROJECT_NAME}_cost_functions 
-  ${PROJECT_NAME}_noisy_filters ${PROJECT_NAME}_update_filters ${PROJECT_NAME}_noise_generators
-ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+install(TARGETS
+    ${PROJECT_NAME}
+    ${PROJECT_NAME}_cost_functions
+    ${PROJECT_NAME}_noise_generators
+    ${PROJECT_NAME}_noisy_filters
+    ${PROJECT_NAME}_planner_manager
+    ${PROJECT_NAME}_update_filters
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-install(FILES cost_function_plugins.xml noise_generator_plugins.xml update_filter_plugins.xml planner_manager_plugins.xml noisy_filter_plugins.xml
+install(FILES
+    cost_function_plugins.xml
+    noise_generator_plugins.xml
+    noisy_filter_plugins.xml
+    planner_manager_plugins.xml
+    update_filter_plugins.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 

--- a/stomp_moveit/package.xml
+++ b/stomp_moveit/package.xml
@@ -26,7 +26,6 @@
   <run_depend>moveit_core</run_depend>
   <run_depend>stomp_core</run_depend>
   <run_depend>pluginlib</run_depend>
-  <run_depend>cmake_modules</run_depend>
   <run_depend>kdl_parser</run_depend>
   <run_depend>trac_ik_lib</run_depend>
   <run_depend>eigen_conversions</run_depend>

--- a/stomp_moveit/package.xml
+++ b/stomp_moveit/package.xml
@@ -1,36 +1,28 @@
 <?xml version="1.0"?>
-<package>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
   <name>stomp_moveit</name>
   <version>0.1.1</version>
-  <description>The stomp_moveit package</description>
-
+  <description>The stomp_moveit package.</description>
+  <author>Jorge Nicho</author>
   <maintainer email="jrgnichodevel@gmail.com">Jorge Nicho</maintainer>
   <license>Apache 2.0</license>
-  <author email="jrgnichodevel@gmail.com">Jorge Nicho</author>
-  <url type="website">http://ros.org/wiki/stomp_moveit</url>
+
+  <url type="website">http://wiki.ros.org/stomp_moveit</url>
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>roscpp</build_depend>
-  <build_depend>moveit_ros_planning</build_depend>
-  <build_depend>moveit_core</build_depend>
-  <build_depend>stomp_core</build_depend>
-  <build_depend>pluginlib</build_depend>
   <build_depend>cmake_modules</build_depend>
-  <build_depend>kdl_parser</build_depend>
-  <build_depend>trac_ik_lib</build_depend>
-  <build_depend>eigen_conversions</build_depend>
 
-  <run_depend>roscpp</run_depend>
-  <run_depend>moveit_ros_planning</run_depend>
-  <run_depend>moveit_core</run_depend>
-  <run_depend>stomp_core</run_depend>
-  <run_depend>pluginlib</run_depend>
-  <run_depend>kdl_parser</run_depend>
-  <run_depend>trac_ik_lib</run_depend>
-  <run_depend>eigen_conversions</run_depend>
+  <depend>eigen_conversions</depend>
+  <depend>kdl_parser</depend>
+  <depend>moveit_core</depend>
+  <depend>moveit_ros_planning</depend>
+  <depend>pluginlib</depend>
+  <depend>roscpp</depend>
+  <depend>stomp_core</depend>
+  <depend>trac_ik_lib</depend>
 
-  <!-- The export tag contains other, unspecified, tags -->
   <export>
     <moveit_core plugin="${prefix}/planner_manager_plugins.xml"/>
     <stomp_moveit plugin="${prefix}/cost_function_plugins.xml"/>

--- a/stomp_moveit/package.xml
+++ b/stomp_moveit/package.xml
@@ -13,15 +13,23 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>cmake_modules</build_depend>
+  <build_depend>eigen</build_depend>
 
+  <build_export_depend>eigen</build_export_depend>
+
+  <depend>boost</depend>
   <depend>eigen_conversions</depend>
+  <depend>geometry_msgs</depend>
   <depend>kdl_parser</depend>
   <depend>moveit_core</depend>
+  <depend>moveit_msgs</depend>
   <depend>moveit_ros_planning</depend>
   <depend>pluginlib</depend>
   <depend>roscpp</depend>
   <depend>stomp_core</depend>
+  <depend>tf</depend>
   <depend>trac_ik_lib</depend>
+  <depend>visualization_msgs</depend>
 
   <export>
     <moveit_core plugin="${prefix}/planner_manager_plugins.xml"/>

--- a/stomp_plugins/CMakeLists.txt
+++ b/stomp_plugins/CMakeLists.txt
@@ -27,7 +27,7 @@ add_definitions("-std=c++11")
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS moveit_ros_planning moveit_core stomp_core stomp_moveit cmake_modules pluginlib roscpp
+  CATKIN_DEPENDS moveit_ros_planning moveit_core stomp_core stomp_moveit pluginlib roscpp
   DEPENDS EIGEN3
 )
 

--- a/stomp_plugins/CMakeLists.txt
+++ b/stomp_plugins/CMakeLists.txt
@@ -1,13 +1,16 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(stomp_plugins)
 find_package(catkin REQUIRED COMPONENTS
-  roscpp
+  cmake_modules
+  eigen_conversions
   moveit_core
   moveit_ros_planning
+  pluginlib
+  rosconsole
+  roslib
   stomp_core
   stomp_moveit
-  cmake_modules
-  pluginlib
+  xmlrpcpp
 )
 
 find_package(Eigen3 REQUIRED)
@@ -27,8 +30,17 @@ add_definitions("-std=c++11")
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS moveit_ros_planning moveit_core stomp_core stomp_moveit pluginlib roscpp
-  DEPENDS EIGEN3
+  CATKIN_DEPENDS
+    eigen_conversions
+    moveit_core
+    moveit_ros_planning
+    pluginlib
+    rosconsole
+    roslib
+    stomp_core
+    stomp_moveit
+    xmlrpcpp
+  DEPENDS Boost EIGEN3
 )
 
 ###########
@@ -38,6 +50,7 @@ catkin_package(
 ## Specify additional locations of header files
 include_directories(include
   ${catkin_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIRS}
 )
 

--- a/stomp_plugins/package.xml
+++ b/stomp_plugins/package.xml
@@ -1,33 +1,26 @@
 <?xml version="1.0"?>
-<package>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
   <name>stomp_plugins</name>
   <version>0.1.1</version>
-  <description>The stomp_plugins package</description>
-
+  <description>The stomp_plugins package.</description>
+  <author>Jorge Nicho</author>
   <maintainer email="jrgnichodevel@gmail.com">Jorge Nicho</maintainer>
   <license>Apache 2.0</license>
-  <author email="jrgnichodevel@gmail.com">Jorge Nicho</author>
-  <url type="website">http://ros.org/wiki/stomp_plugins</url>
+
+  <url type="website">http://wiki.ros.org/stomp_plugins</url>
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>roscpp</build_depend>
-  <build_depend>moveit_ros_planning</build_depend>
-  <build_depend>moveit_core</build_depend>
-  <build_depend>stomp_core</build_depend>
-  <build_depend>stomp_moveit</build_depend>
-  <build_depend>pluginlib</build_depend>
   <build_depend>cmake_modules</build_depend>
 
-  <run_depend>roscpp</run_depend>
-  <run_depend>moveit_ros_planning</run_depend>
-  <run_depend>moveit_core</run_depend>
-  <run_depend>stomp_core</run_depend>
-  <run_depend>stomp_moveit</run_depend>
-  <run_depend>pluginlib</run_depend>
+  <depend>moveit_core</depend>
+  <depend>moveit_ros_planning</depend>
+  <depend>pluginlib</depend>
+  <depend>roscpp</depend>
+  <depend>stomp_core</depend>
+  <depend>stomp_moveit</depend>
 
-
-  <!-- The export tag contains other, unspecified, tags -->
   <export>
     <stomp_moveit plugin="${prefix}/noise_generator_plugins.xml"/>    
     <stomp_moveit plugin="${prefix}/cost_function_plugins.xml"/>

--- a/stomp_plugins/package.xml
+++ b/stomp_plugins/package.xml
@@ -25,7 +25,6 @@
   <run_depend>stomp_core</run_depend>
   <run_depend>stomp_moveit</run_depend>
   <run_depend>pluginlib</run_depend>
-  <run_depend>cmake_modules</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/stomp_plugins/package.xml
+++ b/stomp_plugins/package.xml
@@ -14,15 +14,20 @@
 
   <build_depend>cmake_modules</build_depend>
 
+  <depend>boost</depend>
+  <depend>eigen</depend>
+  <depend>eigen_conversions</depend>
   <depend>moveit_core</depend>
   <depend>moveit_ros_planning</depend>
   <depend>pluginlib</depend>
-  <depend>roscpp</depend>
+  <depend>rosconsole</depend>
+  <depend>roslib</depend>
   <depend>stomp_core</depend>
   <depend>stomp_moveit</depend>
+  <depend>xmlrpcpp</depend>
 
   <export>
-    <stomp_moveit plugin="${prefix}/noise_generator_plugins.xml"/>    
+    <stomp_moveit plugin="${prefix}/noise_generator_plugins.xml"/>
     <stomp_moveit plugin="${prefix}/cost_function_plugins.xml"/>
     <stomp_moveit plugin="${prefix}/update_filter_plugins.xml"/>
     <rosdoc config="rosdoc.yaml"/>


### PR DESCRIPTION
As per title.

No functional changes to any part of the code.

Packages manifests were missing quite some dependencies, but due to transitive dependencies, things still compiled. That is brittle though, so I made many of them explicit in the packages where they were first-level includes.
