### PR TITLE
Collision check simplified

### DIFF
--- a/stomp_moveit/include/stomp_moveit/cost_functions/collision_check.h
+++ b/stomp_moveit/include/stomp_moveit/cost_functions/collision_check.h
@@ -143,11 +143,6 @@ protected:
   Eigen::VectorXd raw_costs_;
   Eigen::ArrayXd intermediate_costs_slots_;
 
-  // collision
-  collision_detection::CollisionRequest collision_request_;
-  collision_detection::CollisionRobotConstPtr collision_robot_;
-  collision_detection::CollisionWorldConstPtr collision_world_;
-
   // intermediate collision check support
   std::array<moveit::core::RobotStatePtr,3 > intermediate_coll_states_;   /**< @brief Used in checking collisions between to consecutive poses*/
 

--- a/stomp_moveit/src/cost_functions/collision_check.cpp
+++ b/stomp_moveit/src/cost_functions/collision_check.cpp
@@ -274,8 +274,8 @@ bool CollisionCheck::computeCosts(const Eigen::MatrixXd& parameters,
     {
       if(!checkIntermediateCollisions(parameters.col(t),parameters.col(t+1),longest_valid_joint_move_))
       {
-        raw_costs_(t) = 1.0;
-        raw_costs_(t+1) = 1.0;
+        raw_costs_(t) = collision_penalty_;
+        raw_costs_(t+1) = collision_penalty_;
         validity = false;
         skip_next_check = true;
       }
@@ -349,7 +349,7 @@ bool CollisionCheck::checkIntermediateCollisions(const Eigen::VectorXd& start,
   {
     interval = i*dt;
     start_state->interpolate(*end_state,interval,*mid_state) ;
-    if(planning_scene_->isStateColliding(*mid_state))
+    if(planning_scene_->isStateColliding(*mid_state, group_name_))
     {
       return false;
     }


### PR DESCRIPTION
This simplifies the collision checking a bit by using the PlanningScene API instead of copying it. It also contains two small performance optimizations/bug fixes:

- only check the current group in intermediate steps (bugfix for multi-robot setups or scenes where something in the scene is colliding all the time)
- if self-collision-checking fails, don't check world collision (implicit by using the PlanningScene API)