### PR TITLE
Patch for new unified collision API in MoveIt

### DIFF
--- a/stomp_moveit/include/stomp_moveit/cost_functions/collision_check.h
+++ b/stomp_moveit/include/stomp_moveit/cost_functions/collision_check.h
@@ -145,8 +145,7 @@ protected:
 
   // collision
   collision_detection::CollisionRequest collision_request_;
-  collision_detection::CollisionRobotConstPtr collision_robot_;
-  collision_detection::CollisionWorldConstPtr collision_world_;
+  collision_detection::CollisionEnvConstPtr collision_env_;
 
   // intermediate collision check support
   std::array<moveit::core::RobotStatePtr,3 > intermediate_coll_states_;   /**< @brief Used in checking collisions between to consecutive poses*/

--- a/stomp_moveit/src/cost_functions/collision_check.cpp
+++ b/stomp_moveit/src/cost_functions/collision_check.cpp
@@ -165,8 +165,7 @@ bool CollisionCheck::setMotionPlanRequest(const planning_scene::PlanningSceneCon
   collision_request_.contacts = true;
   collision_request_.verbose = false;
 
-  collision_robot_ = planning_scene->getCollisionRobot();
-  collision_world_ = planning_scene->getCollisionWorld();
+  collision_env_ = planning_scene->getCollisionEnv();
 
   // storing robot state
   robot_state_.reset(new RobotState(robot_model_ptr_));
@@ -244,13 +243,12 @@ bool CollisionCheck::computeCosts(const Eigen::MatrixXd& parameters,
       // checking robot vs world (attached objects, octomap, not in urdf) collisions
       result_world_collision.distance = std::numeric_limits<double>::max();
 
-      collision_world_->checkRobotCollision(request,
+      collision_env_->checkRobotCollision(request,
                                             result_world_collision,
-                                            *collision_robot_,
                                             *robot_state_,
                                             planning_scene_->getAllowedCollisionMatrix());
 
-      collision_robot_->checkSelfCollision(request,
+      collision_env_->checkSelfCollision(request,
                                            result_robot_collision,
                                            *robot_state_,
                                            planning_scene_->getAllowedCollisionMatrix());

--- a/stomp_plugins/include/stomp_plugins/cost_functions/tool_goal_pose.h
+++ b/stomp_plugins/include/stomp_plugins/cost_functions/tool_goal_pose.h
@@ -28,8 +28,7 @@
 
 #include <Eigen/Sparse>
 #include <moveit/robot_model/robot_model.h>
-#include <moveit/collision_detection_fcl/collision_world_fcl.h>
-#include <moveit/collision_detection_fcl/collision_robot_fcl.h>
+#include <moveit/collision_detection_fcl/collision_env_fcl.h>
 #include <stomp_moveit/utils/kinematics.h>
 #include "stomp_moveit/cost_functions/stomp_cost_function.h"
 


### PR DESCRIPTION
This is a patch for the new unified `CollisionEnv` in MoveIt. Replaces `getCollisionRobot` and `getCollisionWorld` through `getCollisionEnv`.