### PR TITLE
remove superfluous (deprecated) includes

### DIFF
--- a/stomp_plugins/include/stomp_plugins/cost_functions/tool_goal_pose.h
+++ b/stomp_plugins/include/stomp_plugins/cost_functions/tool_goal_pose.h
@@ -28,8 +28,6 @@
 
 #include <Eigen/Sparse>
 #include <moveit/robot_model/robot_model.h>
-#include <moveit/collision_detection_fcl/collision_world_fcl.h>
-#include <moveit/collision_detection_fcl/collision_robot_fcl.h>
 #include <stomp_moveit/utils/kinematics.h>
 #include "stomp_moveit/cost_functions/stomp_cost_function.h"
 


### PR DESCRIPTION
The includes are not used in the header and break compatibility with MoveIt's `master` branch at the moment.

I wanted to have this as part of #4 already, but @jrgnicho merged it before @simonschmeisser could add it to the pull-request branch. :)