### PR TITLE
use EigenStl wherever possible

### DIFF
--- a/stomp_moveit/include/stomp_moveit/utils/kinematics.h
+++ b/stomp_moveit/include/stomp_moveit/utils/kinematics.h
@@ -28,6 +28,7 @@
 
 #include <ros/console.h>
 #include <Eigen/Geometry>
+#include <Eigen/StdVector>
 #include <eigen_conversions/eigen_msg.h>
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/robot_state/conversions.h>
@@ -39,6 +40,11 @@
 #include <trac_ik/trac_ik.hpp>
 #include <boost/optional.hpp>
 
+
+namespace EigenSTL
+{
+  typedef std::vector<Eigen::Affine3d, Eigen::aligned_allocator<Eigen::Affine3d>> vector_Affine3d;
+}
 
 namespace stomp_moveit
 {
@@ -179,9 +185,9 @@ namespace kinematics
    * @param max_samples           Maximum number of samples to be generated
    * @return The sampled poses
    */
-  std::vector<Eigen::Affine3d> sampleCartesianPoses(const moveit_msgs::Constraints& c,
-                                                    const std::vector<double> sampling_resolution = {0.05, 0.05, 0.05, M_PI_2,M_PI_2,M_PI_2},
-                                                    int max_samples =20 );
+  EigenSTL::vector_Affine3d sampleCartesianPoses(const moveit_msgs::Constraints& c,
+                                                 const std::vector<double> sampling_resolution = {0.05, 0.05, 0.05, M_PI_2,M_PI_2,M_PI_2},
+                                                 int max_samples =20 );
 
 
 /**

--- a/stomp_moveit/src/utils/kinematics.cpp
+++ b/stomp_moveit/src/utils/kinematics.cpp
@@ -448,11 +448,10 @@ bool decodeCartesianConstraint(moveit::core::RobotModelConstPtr model,const move
   return true;
 }
 
-std::vector<Eigen::Affine3d> sampleCartesianPoses(const moveit_msgs::Constraints& c,const std::vector<double> sampling_resolution,int max_samples)
+EigenSTL::vector_Affine3d sampleCartesianPoses(const moveit_msgs::Constraints& c,const std::vector<double> sampling_resolution,int max_samples)
 {
   using namespace Eigen;
-
-  std::vector<Eigen::Affine3d> poses;
+  EigenSTL::vector_Affine3d poses;
 
   // random generator
   std::random_device rd;


### PR DESCRIPTION
https://eigen.tuxfamily.org/dox/group__DenseMatrixManipulation__Alignement.html

> Using STL containers on fixed-size vectorizable Eigen types, or classes having members of such types, requires taking the following two steps:
> 
>  - A 16-byte-aligned allocator must be used. Eigen does provide one ready for use: aligned_allocator. 
>  - If you want to use the std::vector container, you need to #include <Eigen/StdVector>. 
>
> These issues arise only with fixed-size vectorizable Eigen types and structures having such Eigen objects as member. For other Eigen types, such as Vector3f or MatrixXd, no special care is needed when using STL containers.