### PR TITLE
Fix plan problems

### DIFF
--- a/stomp_moveit/src/noisy_filters/joint_limits.cpp
+++ b/stomp_moveit/src/noisy_filters/joint_limits.cpp
@@ -102,6 +102,7 @@ bool JointLimits::setMotionPlanRequest(const planning_scene::PlanningSceneConstP
   error_code.val = error_code.val | moveit_msgs::MoveItErrorCodes::SUCCESS;
 
   // saving start state
+  *start_state_ = planning_scene->getCurrentState();
   if(!robotStateMsgToRobotState(req.start_state,*start_state_))
   {
     ROS_ERROR_STREAM("Failed to save start state");


### PR DESCRIPTION
Since the req has nothing content about robot start_state, so it will cause error when update parameter_optimized,robotStateMsgToRobotState(req.start_state,*start_state_) will  not fill start_state.