### PR TITLE
Fix goal position tolerances from box primitive

### DIFF
--- a/stomp_moveit/src/utils/kinematics.cpp
+++ b/stomp_moveit/src/utils/kinematics.cpp
@@ -366,9 +366,9 @@ bool decodeCartesianConstraint(moveit::core::RobotModelConstPtr model,const move
        }
 
        using SP = shape_msgs::SolidPrimitive;
-       tolerance[0] = bv.dimensions[SP::BOX_X];
-       tolerance[1] = bv.dimensions[SP::BOX_Y];
-       tolerance[2] = bv.dimensions[SP::BOX_Z];
+       tolerance[0] = bv.dimensions[SP::BOX_X] / 2.0;
+       tolerance[1] = bv.dimensions[SP::BOX_Y] / 2.0;
+       tolerance[2] = bv.dimensions[SP::BOX_Z] / 2.0;
      }
      break;
 
@@ -497,9 +497,9 @@ EigenSTL::vector_Affine3d sampleCartesianPoses(const moveit_msgs::Constraints& c
         }
 
         using SP = shape_msgs::SolidPrimitive;
-        tolerances[0] = bv.dimensions[SP::BOX_X];
-        tolerances[1] = bv.dimensions[SP::BOX_Y];
-        tolerances[2] = bv.dimensions[SP::BOX_Z];
+        tolerances[0] = bv.dimensions[SP::BOX_X] / 2.0;
+        tolerances[1] = bv.dimensions[SP::BOX_Y] / 2.0;
+        tolerances[2] = bv.dimensions[SP::BOX_Z] / 2.0;
       }
       break;
 


### PR DESCRIPTION
Converting a position constraint from a box primitive with dimension into absolute tolerances results in
doubling the tolerances wrt. the pose of the box. The sphere primitive doesn't suffer from this because the radius is taken and not the diameter. This may also resolve PR #25.

The goal position constraint used in the images below is a box primitive (see white box from left image). The start state is always the start of the segment path (leftmost).

The first two images below is the result of one run of STOMP using the described constraint. The end goal of the STOMP segment (rightmost) `panda_link8` should be within the white box. I guess that STOMP chooses a random end goal within the constraint. We clearly see that the goal tolerances are not respected.

<p align="middle">
<img src="https://user-images.githubusercontent.com/32679594/122853444-3b0ac180-d2e0-11eb-892e-25734b9c3cf9.png" width="48%" />
<img src="https://user-images.githubusercontent.com/32679594/122853470-465ded00-d2e0-11eb-9cd3-b0ea8fbc1560.png" width="41.6%" /> 
</p>

With this PR, the goal (blue line rightmost segment) is within the white box tolerances.
<p align="middle">
<img src="https://user-images.githubusercontent.com/32679594/122854873-5f679d80-d2e2-11eb-83b8-89226cb314ed.png" width="48%" />
<img src="https://user-images.githubusercontent.com/32679594/122854885-62628e00-d2e2-11eb-8299-4881e43037b9.png" width="43.7%" /> 
</p>



